### PR TITLE
fix(jenkins): Convert submodules to SSH refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ shared-*/
 
 # dynamically created by the build script
 conf-notes.txt
+
+# tmp files
+*.swp
+*.swo

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "resin-device-types"]
 	path = resin-device-types
-	url = https://github.com/resin-io/resin-device-types.git
+	url = git@github.com:resin-io/resin-device-types.git
 [submodule "resin-yocto-scripts"]
 	path = resin-yocto-scripts
-	url = https://github.com/resin-os/resin-yocto-scripts.git
+	url = git@github.com:resin-os/resin-yocto-scripts.git
 [submodule "layers/meta-artik"]
 	path = layers/meta-artik
-	url = https://github.com/resin-os/meta-artik.git
+	url = git@github.com:resin-os/meta-artik.git
 [submodule "layers/meta-artik710"]
 	path = layers/meta-artik710
-	url = https://github.com/resin-os/meta-artik710.git
+	url = git@github.com:resin-os/meta-artik710.git
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
-	url = https://github.com/openembedded/meta-openembedded.git
+	url = git@github.com:openembedded/meta-openembedded.git
 [submodule "layers/meta-resin"]
 	path = layers/meta-resin
-	url = https://github.com/resin-os/meta-resin.git
+	url = git@github.com:resin-os/meta-resin.git
 [submodule "layers/poky"]
 	path = layers/poky
-	url = https://git.yoctoproject.org/git/poky
+	url = git@git.yoctoproject.org:git/poky
 [submodule "layers/oe-meta-go"]
 	path = layers/oe-meta-go
-	url = https://github.com/mem/oe-meta-go.git
+	url = git@github.com:mem/oe-meta-go.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Convert git submodule references to SSH [Jack]
+
 # v1.8.0 - 2016-08-05
 
 * Initial Artik710 support [Andrei]


### PR DESCRIPTION
This allows recursively cloning submodules on Jenkins builds.
