### PR TITLE
networkmanager_%.bbappend: Disable random MAC

### DIFF
--- a/layers/meta-resin-artik710/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-resin-artik710/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,8 @@
+do_install_append() {
+    # don't enable random mac address for scanning on artik710
+    cat >> ${D}${sysconfdir}/NetworkManager/NetworkManager.conf <<EOF
+
+[device]
+wifi.scan-rand-mac-address=no
+EOF
+}


### PR DESCRIPTION
address when scanning

Disabling this fixes the issue with wifi being connected after more than
5 minutes, usually after seeing a lot of:

artik710 NetworkManager[359]: <info>  [1477423805.8036] device (wlan0): supplicant interface state: inactive -> disabled
artik710 NetworkManager[359]: <info>  [1477423805.8904] device (wlan0): supplicant interface state: disabled -> inactive
artik710 NetworkManager[359]: <warn>  [1477423806.0279] device (wlan0): set-hw-addr: new MAC address 7E:E0:3D:48:C1:D8 not successfully set (scanning)
artik710 NetworkManager[359]: <info>  [1477423806.0869] device (wlan0): supplicant interface state: inactive -> disabled
artik710 NetworkManager[359]: <info>  [1477423806.2104] device (wlan0): supplicant interface state: disabled -> inactive
artik710 NetworkManager[359]: <warn>  [1477423806.3478] device (wlan0): set-hw-addr: new MAC address 7E:E0:3D:48:C1:D8 not successfully set (scanning)
artik710 NetworkManager[359]: <info>  [1477423806.4028] device (wlan0): supplicant interface state: inactive -> disabled
artik710 NetworkManager[359]: <info>  [1477423806.4800] device (wlan0): supplicant interface state: disabled -> inactive

Signed-off-by: Florin Sarbu <florin@resin.io>