### PR TITLE
Re-enable UPX on AArch64

### DIFF
--- a/layers/meta-resin-artik710/recipes-containers/docker/docker_git.bbappend
+++ b/layers/meta-resin-artik710/recipes-containers/docker/docker_git.bbappend
@@ -1,2 +1,0 @@
-# UPX not supported on aarch64
-FILES_COMPRESS_artik710 = ""

--- a/layers/meta-resin-artik710/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bbappend
+++ b/layers/meta-resin-artik710/recipes-go/resin-provisioner/resin-provisioner_1.0.4.bbappend
@@ -1,2 +1,0 @@
-# UPX not supported on aarch64
-FILES_COMPRESS_artik710 = ""


### PR DESCRIPTION

Now we have the latest version of UPX we can re-enable executable compression on AArch64.
