### PR TITLE
hostapp-update-hooks: Fix 99-flash-bootloader bootloader md5sum check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Fix 99-flash-bootloader bootloader md5sum check from hostapp-update-hooks [Florin]
+
 # v2.9.6+rev1
 ## (2018-01-15)
 

--- a/layers/meta-resin-artik710/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
+++ b/layers/meta-resin-artik710/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
@@ -40,7 +40,7 @@ for i in $update_files; do
 	let skip_bytes=$block_size*$seek_blocks
 
 	# calculate md5sum of the data already written to $device, using $update_size bytes and skipping $skip_bytes from $device
-	existing_md5sum=$(dd if=$device skip=$skip_bytes bs=1 count=$update_size &>/dev/null | md5sum | awk '{print $1}')
+	existing_md5sum=$(dd if=$device skip=$skip_bytes bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
 
 	if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
 		dd if=/resin-boot/$current_update_file of=$device conv=fdatasync seek=$seek_blocks bs=$block_size


### PR DESCRIPTION
Signed-off-by: Florin Sarbu <florin@resin.io>