### PR TITLE
meta-artik710: Update to e8383b7566ebbff9bdf996b5634613469ba845ec on …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update the meta-artik710 BSP submodule to e8383b7566ebbff9bdf996b5634613469ba845ec (on pyro branch) [Florin]
+
 # v2.12.7+rev1
 ## (2018-05-04)
 


### PR DESCRIPTION
…pyro branch

This update is needed for a fix with cloning the kernel (upstream has re-written the git history)
We also updated the kernel to version 4.4.71 for artik710

Signed-off-by: Florin Sarbu <florin@resin.io>